### PR TITLE
Add windows compatibility fixes

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,6 +7,19 @@
 PineappleCAS is a computer algebra system for the TI-84 Plus CE calculators. It is designed as a faster, cleaner, more useful, memory-leak-free alternative to the <a href="https://github.com/nathanfarlow/SymbolicDerivative">SymbolicDerivative</a> project. PineappleCAS uses the <a href="https://github.com/creachadair/imath">imath library</a> for arbitrary precision math.
 </p>
 
+
+## Credits
+
+- **Original PineappleCAS** by Nathan Farlow
+
+  
+- **Windows compatibility** fixes by [DaiGianna Williams](https://daigianna.com) ([GitHub](https://github.com/dwilliams808)).
+  
+This includes:
+- Fix for `_expand` naming conflict with Windows system headers
+- Windows-compatible makefile (`pc.windows.makefile`)
+
+
 <hr>
 
 ## Screenshots
@@ -157,11 +170,3 @@ Remember that you can definitely use strings as input and output as well. You ca
 :End
 ```
 
-
-## Credits
-
-- **Original PineappleCAS** by Nathan Farlow
-- **Windows compatibility** fixes by [DaiGianna Williams](https://daigianna.com) ([GitHub](https://github.com/dwilliams808)).
-This includes:
-- Fix for `_expand` naming conflict with Windows system headers
-- Windows-compatible makefile (`pc.windows.makefile`)

--- a/README.md
+++ b/README.md
@@ -161,7 +161,7 @@ Remember that you can definitely use strings as input and output as well. You ca
 ## Credits
 
 - **Original PineappleCAS** by Nathan Farlow
-Windows compatibility fixes by [DaiGianna Williams](https://daigianna.com) ([GitHub](https://github.com/dwilliams808)).
+- **Windows compatibility** fixes by [DaiGianna Williams](https://daigianna.com) ([GitHub](https://github.com/dwilliams808)).
 This includes:
 - Fix for `_expand` naming conflict with Windows system headers
 - Windows-compatible makefile (`pc.windows.makefile`)

--- a/README.md
+++ b/README.md
@@ -156,3 +156,12 @@ Remember that you can definitely use strings as input and output as well. You ca
 :Disp "FAIL :("
 :End
 ```
+
+
+## Credits
+
+- **Original PineappleCAS** by Nathan Farlow
+Windows compatibility fixes by [DaiGianna Williams](https://daigianna.com) ([GitHub](https://github.com/dwilliams808)).
+This includes:
+- Fix for `_expand` naming conflict with Windows system headers
+- Windows-compatible makefile (`pc.windows.makefile`)

--- a/pc.windows.makefile
+++ b/pc.windows.makefile
@@ -1,0 +1,37 @@
+# Windows-compatible Makefile for PineappleCAS
+# Original pc.makefile by yanick.rochon@gmail.com
+# Windows adaptation by DaiGianna Williams - GitHub: dwilliams808 - Website: daigianna.com)
+TARGET   = pineapple.exe
+
+CC       = gcc
+CFLAGS   = -std=c89 -ansi -pedantic -g -DCOMPILE_PC -DDEBUG -Wall -I.
+
+LINKER   = gcc
+LFLAGS   = -Wall -I. -lm
+
+SRCDIR   = src
+OBJDIR   = obj
+BINDIR   = bin
+
+SOURCES  := $(wildcard $(SRCDIR)/*.c) $(wildcard $(SRCDIR)/*/*.c) $(wildcard $(SRCDIR)/*/*/*.c)
+OBJECTS  := $(SOURCES:$(SRCDIR)/%.c=$(OBJDIR)/%.o)
+
+$(BINDIR)/$(TARGET): $(OBJECTS)
+	@if not exist $(subst /,\,$(@D)) mkdir $(subst /,\,$(@D))
+	@$(LINKER) $(OBJECTS) $(LFLAGS) -o $@
+	@echo Linking complete!
+
+$(OBJECTS): $(OBJDIR)/%.o : $(SRCDIR)/%.c
+	@if not exist $(subst /,\,$(@D)) mkdir $(subst /,\,$(@D))
+	@$(CC) $(CFLAGS) -c $< -o $@
+	@echo Compiled $< successfully!
+
+.PHONY: clean
+clean:
+	@if exist $(subst /,\,$(OBJDIR)) rmdir /s /q $(subst /,\,$(OBJDIR))
+	@echo Cleanup complete!
+
+.PHONY: remove
+remove: clean
+	@if exist $(BINDIR)/$(TARGET) del $(subst /,\,$(BINDIR)/$(TARGET))
+	@echo Executable removed!

--- a/src/cas/expand.c
+++ b/src/cas/expand.c
@@ -29,14 +29,14 @@ pcas_ast_t *combine(pcas_ast_t *add, pcas_ast_t *b) {
     return expanded;
 }
 
-static bool _expand(pcas_ast_t *e, unsigned char flags) {
+static bool cas_expand(pcas_ast_t *e, unsigned char flags) {
     unsigned i, j;
 
     bool did_change = false;
     bool intermediate_change = false;
 
     for(i = 0; i < ast_ChildLength(e); i++)
-        did_change |= _expand(ast_ChildGet(e, i), flags);
+        did_change |= cas_expand(ast_ChildGet(e, i), flags);
 
     do {
         intermediate_change = false;
@@ -86,7 +86,7 @@ static bool _expand(pcas_ast_t *e, unsigned char flags) {
 
             }
 
-        } 
+        }
 
         if((flags & EXP_DISTRIB_DIVISION) && isoptype(e, OP_DIV)) {
             pcas_ast_t *num, *den;
@@ -98,7 +98,7 @@ static bool _expand(pcas_ast_t *e, unsigned char flags) {
             replace_node(e, ast_MakeBinary(OP_MULT, ast_Copy(num), ast_MakeBinary(OP_DIV, ast_MakeNumber(num_FromInt(1)), ast_Copy(den))));
 
             /*This could be dangerous, but we'll cross that bridge when we get there.*/
-            _expand(e, EXP_DISTRIB_NUMBERS | EXP_DISTRIB_ADDITION | EXP_DISTRIB_MULTIPLICATION | EXP_DISTRIB_ADDITION | EXP_DISTRIB_POWERS);
+            cas_expand(e, EXP_DISTRIB_NUMBERS | EXP_DISTRIB_ADDITION | EXP_DISTRIB_MULTIPLICATION | EXP_DISTRIB_ADDITION | EXP_DISTRIB_POWERS);
 
             intermediate_change = true;
             did_change = true;
@@ -184,7 +184,7 @@ bool expand(pcas_ast_t *e, unsigned char flags) {
     bool changed = false;
     /*Expand powers first to make things faster*/
     if(flags & EXP_EXPAND_POWERS)
-        changed |= _expand(e, EXP_EXPAND_POWERS);
-    changed |= _expand(e, flags & ~EXP_EXPAND_POWERS);
+        changed |= cas_expand(e, EXP_EXPAND_POWERS);
+    changed |= cas_expand(e, flags & ~EXP_EXPAND_POWERS);
     return changed;
 }


### PR DESCRIPTION
This PR adds Windows compatibility to PineappleCAS:

- Rename `_expand` to `cas_expand` in `src/cas/expand.c` to avoid
  conflict with Windows system header `malloc.h`.
- Add `pc.windows.makefile` for building on Windows with MinGW-w64
  or Git Bash.

Tested on Windows 10/11 with MinGW-w64 and Git Bash.